### PR TITLE
chore: Add go.mod file for module configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/JM-Murray-Holdings/BobShop
+
+go 1.22.4


### PR DESCRIPTION
A new go.mod file has been added to the repository to configure the module as "github.com/JM-Murray-Holdings/BobShop" with a required Go version of 1.22.4.